### PR TITLE
chore(package.json): add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "main": "desktop.js",
   "description": "sikher: An Ionic project",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/sikher/sikher.git"
+  }
   "dependencies": {
     "grunt": "^0.4.5",
     "grunt-download-atom-shell": "^0.12.0",


### PR DESCRIPTION
Previously, `package.json` did not contain the repository field that
would link the project to GitHub. This also has the added side effect of
removing a warning when running `npm install`.